### PR TITLE
Fallback to ACE Medical's volume-based CPR success chance

### DIFF
--- a/addons/circulation/functions/fnc_cprLocal.sqf
+++ b/addons/circulation/functions/fnc_cprLocal.sqf
@@ -2,6 +2,7 @@
 /*
  * Author: Glowbal
  * Edit: Tomcat
+ * Edit: TheSavageCoder
  * Overwrites the cprLocal of ACE to add the success chance for AED and AED-X
  *
  * Arguments:
@@ -24,56 +25,67 @@ params [
 	["_reviveObject","CPR",[""]]
 ];
 
-private _chance = 0;
-private _random = random 100;
-private _randomCPR = random 1;
+// String identifier for the activity that was performed. Empty string means no activity taken.
+private _activity = "";
+// Indicates if our activity was successful or not
+private _success = false;
+
+// Calculates random success based on an integer chance between 0 and 100
+private _randomSuccess = {
+	params ["_chance"];
+	(random 100) <= _chance;
+};
 
 switch (_reviveObject) do {
 	case "CPR": {
-		[_patient, "activity", "STR_ACE_medical_treatment_Activity_CPR", [[_medic, false, true] call ace_common_fnc_getName]] call ace_medical_treatment_fnc_addToLog;
-		_chance = ace_medical_treatment_cprSuccessChanceMin;
+		_activity = "STR_ACE_medical_treatment_Activity_CPR";
+
+		// Check if medic class based CPR chances are enabled
 		if (GVAR(enable_CPR_Chances)) then {
 			switch (_medic getVariable ["ace_medical_medicClass",0]) do {
 				case 0: {
-					_chance = GVAR(CPR_Chance_Default);
+					_success = GVAR(CPR_Chance_Default) call _randomSuccess;
 				};
 				case 1: {
-					_chance = GVAR(CPR_Chance_RegularMedic);
+					_success = GVAR(CPR_Chance_RegularMedic) call _randomSuccess;
 				};
 				case 2: {
-					_chance = GVAR(CPR_Chance_Doctor);
+					_success = GVAR(CPR_Chance_Doctor) call _randomSuccess;
 				};
 			};
+		} else {
+			/*
+				Fallback to same calculation of chance as ACE Medical Treatment's cprLocal
+				SEE: https://github.com/acemod/ACE3/blob/master/addons/medical_treatment/functions/fnc_cprLocal.sqf
+
+				BLOOD_VOLUME_CLASS_* and GET_BLOOD_VOLUME() macros are imported from the ACE medical_engine script macros
+			*/
+			private _min = ace_medical_treatment_cprSuccessChanceMin;
+			private _max = ace_medical_treatment_cprSuccessChanceMax;
+			private _chance = linearConversion [BLOOD_VOLUME_CLASS_4_HEMORRHAGE, BLOOD_VOLUME_CLASS_2_HEMORRHAGE, GET_BLOOD_VOLUME(_patient), _min, _max, true];
+			// ACE Medical settings are percentages (decimals, 0 <= x <= 1) instead of integers
+			_success = (random 1) < _chance;
 		};
 	};
 	case "AED": {
-		[_patient, "activity", "STR_ACE_Medical_Treatment_Activity_AED", [[_medic, false, true] call ace_common_fnc_getName]] call ace_medical_treatment_fnc_addToLog;
-		_chance = GVAR(SuccesCh_AED);
+		// TODO: ACE Pharmacy actions should use STR_ACEP_circulation_Activity_* format instead of the ACE module format
+		_activity = "STR_ACE_Medical_Treatment_Activity_AED";
+		_success = GVAR(SuccesCh_AED) call _randomSuccess;
 	};
 	case "AED-Station": {
-		[_patient, "activity", "STR_ACE_Medical_Treatment_Activity_AEDS", [[_medic, false, true] call ace_common_fnc_getName]] call ace_medical_treatment_fnc_addToLog;
-		_chance = GVAR(SuccesCh_AED);
+		_activity = "STR_ACE_Medical_Treatment_Activity_AEDS";
+		_success = GVAR(SuccesCh_AED) call _randomSuccess;
 	};
 	case "AED-X": {
-		[_patient, "activity", "STR_ACE_Medical_Treatment_Activity_AEDX", [[_medic, false, true] call ace_common_fnc_getName]] call ace_medical_treatment_fnc_addToLog;
-		_chance = GVAR(SuccesCh_AED_X);
+		_activity = "STR_ACE_Medical_Treatment_Activity_AEDX";
+		_success = GVAR(SuccesCh_AED_X) call _randomSuccess;
 	};
 };
 
-if (_reviveObject isEqualTo "AED" || _reviveObject isEqualTo "AED-X" || _reviveObject isEqualTo "AED-Station") exitWith {
-	if (_random <= _chance) then {
+// If an activity was performed, log it and check if CPR was successful.
+if (_activity != "") exitWith {
+	[_patient, "activity", _activity, [[_medic, false, true] call ace_common_fnc_getName]] call ace_medical_treatment_fnc_addToLog;
+	if (_success) then {
 		["ace_medical_CPRSucceeded", _patient] call CBA_fnc_localEvent;
 	};
 };
-if !(GVAR(enable_CPR_Chances)) then {
-	if (_randomCPR > _chance) then {
-		["ace_medical_CPRSucceeded", _patient] call CBA_fnc_localEvent;
-	};
-} else {
-	if (_random <= _chance) then {
-		["ace_medical_CPRSucceeded", _patient] call CBA_fnc_localEvent;
-	};
-};
-
-
-


### PR DESCRIPTION
Consolidates and reduces activity-specific logic to increase readability.

Just using `ace_medical_treatment_cprSuccessChanceMin` is not sufficient in many cases where a group has configured little or no chance of CPR success when an individual has fatal blood loss.

Additionally, this makes me wonder if the per-level success chances should also be based on blood volume as this mod targets ACE Medical integration.